### PR TITLE
STOMP 메시징 채팅

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -42,6 +42,13 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.webjars:sockjs-client:1.1.2'
+
+    // stomp
+    implementation 'org.webjars:stomp-websocket:2.3.3-1'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/backend/BackendApplication.java
+++ b/backend/src/main/java/com/example/backend/BackendApplication.java
@@ -3,9 +3,11 @@ package com.example.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = {"com.example.backend", "com.tripmarket"})
 @EntityScan(basePackages = {"com.tripmarket.domain"})
+@EnableJpaRepositories(basePackages = "com.tripmarket.domain.chatting.repository")
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/tripmarket/domain/chatting/controller/ChatController.java
+++ b/backend/src/main/java/com/tripmarket/domain/chatting/controller/ChatController.java
@@ -1,0 +1,25 @@
+package com.tripmarket.domain.chatting.controller;
+
+import com.tripmarket.domain.chatting.dto.MessageDto;
+import com.tripmarket.domain.chatting.service.MessageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class ChatController {
+
+	private final MessageService messageService;
+
+	@MessageMapping("chat.message.{roomId}")
+	public void message(@DestinationVariable String roomId, MessageDto messageDto) {
+		log.info("메세지 전달 완료 {}: {}", roomId, messageDto);
+		messageService.sendMessageToRoom(messageDto);
+	}
+}

--- a/backend/src/main/java/com/tripmarket/domain/chatting/controller/WebSocketEventController.java
+++ b/backend/src/main/java/com/tripmarket/domain/chatting/controller/WebSocketEventController.java
@@ -1,0 +1,34 @@
+package com.tripmarket.domain.chatting.controller;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@Slf4j
+public class WebSocketEventController {
+
+	@EventListener
+	public void handleWebSocketConnectListener(SessionConnectEvent event) {
+		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+		log.info("WebSocket 연결: {}", headerAccessor.getSessionId());
+	}
+
+	@EventListener
+	public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+		log.info("WebSocket 연결 해제: {}", headerAccessor.getSessionId());
+	}
+
+	@MessageMapping("/**")
+	public void debugMessages(Message<?> message) {
+		System.out.println("DEBUG: Received raw message - " + message);
+	}
+
+}

--- a/backend/src/main/java/com/tripmarket/domain/chatting/dto/MessageDto.java
+++ b/backend/src/main/java/com/tripmarket/domain/chatting/dto/MessageDto.java
@@ -1,0 +1,28 @@
+package com.tripmarket.domain.chatting.dto;
+
+import com.tripmarket.domain.chatting.entity.Message;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageDto {
+	private String roomId;
+	private String sender;
+	private String toUserId;
+	private String content;
+
+	public Message toMessageEntity(){
+		return Message.builder()
+			.roomId(roomId)
+			.senderId(sender)
+			.toUserId(toUserId)
+			.content(content)
+			.build();
+	}
+}

--- a/backend/src/main/java/com/tripmarket/domain/chatting/entity/Chatting.java
+++ b/backend/src/main/java/com/tripmarket/domain/chatting/entity/Chatting.java
@@ -1,9 +1,8 @@
 package com.tripmarket.domain.chatting.entity;
 
 import com.tripmarket.domain.member.entity.Member;
-import com.tripmarket.domain.chatting.entity.ChattingRoom;
-import com.tripmarket.domain.member.entity.Member;
 import com.tripmarket.global.jpa.entity.BaseEntity;
+
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,19 +12,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Chatting extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chatting_room_id")
-    private ChattingRoom chattingRoom; // 연결된 채팅방
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "chatting_room_id")
+	private ChattingRoom chattingRoom;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private Member user; // 채팅 참여 유저
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private Member user;
 
-    // 생성자
-    public Chatting(ChattingRoom chattingRoom, Member user) {
-        this.chattingRoom = chattingRoom;
-        this.user = user;
-    }
-
+	// 생성자
+	public Chatting(ChattingRoom chattingRoom, Member user) {
+		this.chattingRoom = chattingRoom;
+		this.user = user;
+	}
 
 }

--- a/backend/src/main/java/com/tripmarket/domain/chatting/entity/Message.java
+++ b/backend/src/main/java/com/tripmarket/domain/chatting/entity/Message.java
@@ -1,21 +1,27 @@
 package com.tripmarket.domain.chatting.entity;
 
-import com.tripmarket.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
+
+import com.tripmarket.global.jpa.entity.BaseEntity;
 
 @Getter
-@Entity
 @NoArgsConstructor
+@Entity
 public class Message extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chatting_room_id", nullable = false)
-    private ChattingRoom chattingRoom; // 메시지가 속한 채팅방
+	private String roomId;
+	private String senderId;
+	private String toUserId;
+	private String content;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String content; // 메시지 내용
-
+	@Builder
+	public Message(String roomId, String senderId, String toUserId, String content) {
+		this.roomId = roomId;
+		this.senderId = senderId;
+		this.toUserId = toUserId;
+		this.content = content;
+	}
 }

--- a/backend/src/main/java/com/tripmarket/domain/chatting/repository/MessageRepository.java
+++ b/backend/src/main/java/com/tripmarket/domain/chatting/repository/MessageRepository.java
@@ -1,0 +1,8 @@
+package com.tripmarket.domain.chatting.repository;
+
+import com.tripmarket.domain.chatting.entity.Message;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/backend/src/main/java/com/tripmarket/domain/chatting/service/MessageService.java
+++ b/backend/src/main/java/com/tripmarket/domain/chatting/service/MessageService.java
@@ -1,0 +1,38 @@
+package com.tripmarket.domain.chatting.service;
+
+import com.tripmarket.domain.chatting.dto.MessageDto;
+import com.tripmarket.domain.chatting.entity.Message;
+import com.tripmarket.domain.chatting.repository.MessageRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+	private final MessageRepository messageRepository;
+	private final SimpMessagingTemplate messagingTemplate;
+
+	@Transactional
+	public void sendMessageToRoom(MessageDto messageDto) {
+		// 대상 유저에게 실시간 메시지 전송
+		String destination = "/queue/private." + messageDto.getToUserId();
+		try {
+			messagingTemplate.convertAndSend(destination, messageDto);
+			log.info("메세지가 전송되었습니다 : {}, Destination: {}", messageDto.getToUserId(), destination);
+		} catch (Exception e) {
+			log.error("메세지 전송 실패 : {}", e.getMessage(), e);
+		}
+
+		Message message = messageDto.toMessageEntity();
+		messageRepository.save(message);
+		log.info("메세지가 저장되었습니다 : {}", message.getId());
+
+	}
+}

--- a/backend/src/main/java/com/tripmarket/global/configuration/WebSocketConfig.java
+++ b/backend/src/main/java/com/tripmarket/global/configuration/WebSocketConfig.java
@@ -1,0 +1,30 @@
+package com.tripmarket.global.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+
+	// 애플리케이션 내부에서 사용할 path를 지정할 수 있음
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.enableSimpleBroker("/queue");
+		registry.setApplicationDestinationPrefixes("/pub");
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/chat")
+			.setAllowedOriginPatterns("*");
+
+		registry.addEndpoint("/match")
+			.setAllowedOriginPatterns("*");
+	}
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- STOMP 프로토콜과 WebSocket을 활용하여 실시간 1:1 메시지 전송 기능 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## 📍 **구현된 주요 로직**  

### **1. STOMP 메시지 브로커 설정**  
- 클라이언트가 구독할 경로는 /queue/private.{toUserId}로 설정해 메시지가 수신자에게만 전달되도록 저장 -> 추후 jwt를 사용하여 검증하여야함
- 클라이언트가 서버로 메시지를 보낼 때는 /pub/chat.message.{roomId}로 사용하는중입니다.

---

### **2. 메시지 전송 및 저장 과정**  
1. 클라이언트가 특정 채팅방의 메시지를 /pub/chat.message.{roomId}로 전송  
2. 서버는 메시지를 받아 대상 사용자에게 전달한 후, H2 데이터베이스에 메시지 기록을 저장합니다. -> 현재 메세지 저장이 되는지 확인하기 위함이며 mongodb로 메세지는 저장할 예정
3. 메시지 데이터는 SimpMessagingTemplate을 사용해 실시간으로 전송됩니다.  


## 🚀 **향후 계획 및 확장성**


### **1. RabbitMQ 도입 이유**  
현재는 STOMP의 내장 브로커를 사용해 메시지를 처리하고 있지만, 외부 메시지 브로커를 도입하려고합니다. 외부 메시지 브로커를 사용하려는 이유는 STOMP를 Spring에서는 SimpleBroker라는 메시지 브로커를 통해서 지원을 하는데 이는 메모리 기반으로 작동하기 때문에 단일 서버가 아닌 다중서버에서는 동기화 문제가 발생하게 된다. 이러한 문제를 해결하기 위해서 외부 메시지 브로커를 사용하려 하며 RabbitMQ를 도입하였습니다.

---

### **2. mongodb 도입 이유**  
현재는 h2에 메세지를 저장하는 형식으로 되어있습니다. 하지만, 실시간 채팅 서비스에서는 다량의 메세지를 실시간으로 빠르게 저장하고 조회를 해야하는데 이는 RDBMS는 맞지 않는다고 생각합니다. 따라서, 이러한 문제를 해결하기 위해 mongodb를 도입하려고 합니다.

---

요즘 개인사정으로 계속 조퇴하고 외출하고 해서 작업량도 팀원분들에 비해서 적고 구현도 적게되어있는데 앞으로는 좀 더 분발해서 프로젝트 잘 마치도록 하겠습니다.


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
