### PR TITLE
feat: 소셜 및 일반 로그인 email 중복 처리

### DIFF
--- a/backend/src/main/java/com/tripmarket/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/tripmarket/domain/auth/controller/AuthController.java
@@ -54,11 +54,11 @@ public class AuthController {
 		log.debug("로그인 시도 - email: {}", loginRequestDto.email());
 
 		// 로그인 처리 및 토큰 발급
-		Map<String, String> tokens = authService.login(loginRequestDto);
+		Map<String, Object> tokens = authService.login(loginRequestDto);
 
 		// Access Token 쿠키 설정
-		ResponseCookie accessTokenCookie = cookieUtil.createAccessTokenCookie(tokens.get("accessToken"));
-		ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(tokens.get("refreshToken"));
+		ResponseCookie accessTokenCookie = cookieUtil.createAccessTokenCookie((String)tokens.get("accessToken"));
+		ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie((String)tokens.get("refreshToken"));
 
 		response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
 		response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());

--- a/backend/src/main/java/com/tripmarket/domain/auth/controller/SocialController.java
+++ b/backend/src/main/java/com/tripmarket/domain/auth/controller/SocialController.java
@@ -1,0 +1,63 @@
+package com.tripmarket.domain.auth.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tripmarket.domain.auth.dto.SocialLinkRequest;
+import com.tripmarket.domain.auth.dto.SocialLinkResponse;
+import com.tripmarket.domain.auth.service.SocialAccountService;
+import com.tripmarket.domain.member.entity.Provider;
+import com.tripmarket.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/members/me")
+@RequiredArgsConstructor
+@Tag(name = "Social", description = "소셜 계정 연동 API")
+public class SocialController {
+	private final SocialAccountService socialAccountService;
+
+	@PostMapping("/social-accounts")
+	@Operation(summary = "소셜 계정 연동", description = "현재 로그인된 계정에 소셜 계정을 연동합니다.")
+	@SecurityRequirement(name = "bearerAuth")
+	public ResponseEntity<Void> linkSocialAccount(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid SocialLinkRequest request
+	) {
+		socialAccountService.linkSocialAccount(userDetails.getId(), request);
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
+	@GetMapping("/social-accounts")
+	@Operation(summary = "연동된 소셜 계정 조회", description = "현재 계정에 연동된 소셜 계정 목록을 조회합니다.")
+	@SecurityRequirement(name = "bearerAuth")
+	public ResponseEntity<SocialLinkResponse> getLinkedSocialAccounts(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		return ResponseEntity.status(HttpStatus.OK).body(socialAccountService.getLinkedSocialAccounts(userDetails.getId()));
+	}
+
+	@DeleteMapping("/social-accounts/{provider}")
+	@Operation(summary = "소셜 계정 연동 해제", description = "특정 소셜 계정과의 연동을 해제합니다.")
+	@SecurityRequirement(name = "bearerAuth")
+	public ResponseEntity<Void> unlinkSocialAccount(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable Provider provider
+	) {
+		socialAccountService.unlinkSocialAccount(userDetails.getId(), provider);
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+}

--- a/backend/src/main/java/com/tripmarket/domain/auth/dto/SocialLinkRequest.java
+++ b/backend/src/main/java/com/tripmarket/domain/auth/dto/SocialLinkRequest.java
@@ -1,0 +1,19 @@
+package com.tripmarket.domain.auth.dto;
+
+import com.tripmarket.domain.member.entity.Provider;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "소셜 계정 연동 요청")
+public record SocialLinkRequest (
+	@Schema(description = "소셜 로그인 제공자", example = "KAKAO")
+	@NotNull(message = "소셜 로그인 제공자는 필수입니다.")
+	Provider provider,
+
+	@Schema(description = "소셜 인증 토큰")
+	@NotBlank(message = "소셜 인증 토큰은 필수입니다.")
+	String token
+) {
+}

--- a/backend/src/main/java/com/tripmarket/domain/auth/dto/SocialLinkResponse.java
+++ b/backend/src/main/java/com/tripmarket/domain/auth/dto/SocialLinkResponse.java
@@ -1,0 +1,25 @@
+package com.tripmarket.domain.auth.dto;
+
+import java.util.List;
+
+import com.tripmarket.domain.member.entity.Provider;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "연동된 소셜 계정 목록 응답")
+public record SocialLinkResponse(
+	@Schema(description = "연동된 소셜 계정 목록")
+	List<LinkedSocialAccount> linkedAccounts
+) {
+	@Schema(description = "연동된 소셜 계정 정보")
+	public record LinkedSocialAccount(
+		@Schema(description = "소셜 제공자")
+		Provider provider,
+
+		@Schema(description = "이메일")
+		String email,
+
+		@Schema(description = "연동 일시")
+		String linkedAt
+	) {	}
+}

--- a/backend/src/main/java/com/tripmarket/domain/auth/service/SocialAccountService.java
+++ b/backend/src/main/java/com/tripmarket/domain/auth/service/SocialAccountService.java
@@ -1,0 +1,101 @@
+package com.tripmarket.domain.auth.service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tripmarket.domain.auth.dto.SocialLinkRequest;
+import com.tripmarket.domain.auth.dto.SocialLinkResponse;
+import com.tripmarket.domain.auth.dto.SocialLinkResponse.LinkedSocialAccount;
+import com.tripmarket.domain.member.entity.Member;
+import com.tripmarket.domain.member.entity.Provider;
+import com.tripmarket.domain.member.entity.SocialAccountLink;
+import com.tripmarket.domain.member.repository.MemberRepository;
+import com.tripmarket.domain.member.repository.SocialAccountLinkRepository;
+import com.tripmarket.global.exception.CustomException;
+import com.tripmarket.global.exception.ErrorCode;
+import com.tripmarket.global.oauth2.service.OAuth2UserInfoService;
+import com.tripmarket.global.oauth2.userinfo.OAuth2UserInfo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SocialAccountService {
+	private final MemberRepository memberRepository;
+	private final SocialAccountLinkRepository socialAccountLinkRepository;
+	private final OAuth2UserInfoService oAuth2UserInfoService;
+
+	/**
+	 * 소셜 계정 연동
+	 */
+	@Transactional
+	public void linkSocialAccount(Long memberId, SocialLinkRequest request) {
+		// 회원 조회
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+		// 이미 연동된 계정인지 확인
+		if (member.hasSocialLink(request.provider())) {
+			throw new CustomException(ErrorCode.ALREADY_LINKED_ACCOUNT);
+		}
+
+		// 소셜 사용자 정보 조회
+		OAuth2UserInfo userInfo = oAuth2UserInfoService.loadUserInfoByToken(request.provider(), request.token());
+
+		// 연동 정보 저장
+		SocialAccountLink socialLink = SocialAccountLink.builder()
+				.member(member)
+				.provider(request.provider())
+				.providerId(userInfo.getId())
+				.email(userInfo.getEmail())
+				.name(userInfo.getName())
+				.profileImageUrl(userInfo.getImageUrl())
+				.build();
+
+		member.addSocialLink(socialLink);
+		memberRepository.save(member);
+
+		log.info("계정 연동 완료 - 회원ID: {}, 제공자: {}", memberId, request.provider());
+	}
+
+	/**
+	 * 소셜 계정 연동 해제
+	 */
+	@Transactional
+	public void unlinkSocialAccount(Long memberId, Provider provider) {
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+		if (!member.hasSocialLink(provider)) {
+			throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_NOT_LINKED);
+		}
+
+		member.removeSocialLink(provider);
+		memberRepository.save(member);
+
+		log.info("계정 연동 해제 완료 - 회원ID: {}, 제공자: {}", memberId, provider);
+	}
+
+	/**
+	 * 연동된 소셜 계정 목록 조회
+	 */
+	@Transactional(readOnly = true)
+	public SocialLinkResponse getLinkedSocialAccounts(Long memberId) {
+		List<SocialAccountLink> links = socialAccountLinkRepository.findByMemberId(memberId);
+
+		List<LinkedSocialAccount> linkedAccounts = links.stream()
+				.map(link -> new LinkedSocialAccount(
+						link.getProvider(),
+						link.getEmail(),
+						link.getLinkedAt().format(DateTimeFormatter.ISO_DATE_TIME)))
+				.collect(Collectors.toList());
+
+		return new SocialLinkResponse(linkedAccounts);
+	}
+}

--- a/backend/src/main/java/com/tripmarket/domain/member/entity/SocialAccountLink.java
+++ b/backend/src/main/java/com/tripmarket/domain/member/entity/SocialAccountLink.java
@@ -1,0 +1,93 @@
+package com.tripmarket.domain.member.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "social_account_link",
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"member_id", "provider", "provider_id"})
+	})
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialAccountLink {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private Provider provider;
+
+	@Column(name = "provider_id", nullable = false)
+	private String providerId;
+
+	private String email;
+
+	private String name;
+
+	private String profileImageUrl;
+
+	@Column(name = "linked_at", nullable = false)
+	private LocalDateTime linkedAt;
+
+	@Column(name = "last_used_at")
+	private LocalDateTime lastUsedAt;
+
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	@Builder
+	public SocialAccountLink(Member member, Provider provider, String providerId,
+		String email, String name, String profileImageUrl) {
+		this.member = member;
+		this.provider = provider;
+		this.providerId = providerId;
+		this.email = email;
+		this.name = name;
+		this.profileImageUrl = profileImageUrl;
+		this.linkedAt = LocalDateTime.now();
+	}
+
+	public void updateLastUsed() {
+		this.lastUsedAt = LocalDateTime.now();
+	}
+}

--- a/backend/src/main/java/com/tripmarket/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/tripmarket/domain/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
 
 	Optional<Member> findByEmail(String email);
+
+	Optional<Member> findByEmailAndProvider(String email, Provider provider);
 }

--- a/backend/src/main/java/com/tripmarket/domain/member/repository/SocialAccountLinkRepository.java
+++ b/backend/src/main/java/com/tripmarket/domain/member/repository/SocialAccountLinkRepository.java
@@ -1,0 +1,19 @@
+package com.tripmarket.domain.member.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.tripmarket.domain.member.entity.Provider;
+import com.tripmarket.domain.member.entity.SocialAccountLink;
+
+@Repository
+public interface SocialAccountLinkRepository extends JpaRepository<SocialAccountLink, Long> {
+	Optional<SocialAccountLink> findByProviderAndProviderId(Provider provider, String providerId);
+
+	List<SocialAccountLink> findByMemberId(Long memberId);
+
+	boolean existsByMemberIdAndProvider(Long memberId, Provider provider);
+}

--- a/backend/src/main/java/com/tripmarket/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/tripmarket/global/exception/ErrorCode.java
@@ -12,6 +12,9 @@ public enum ErrorCode {
 	//Member
 	MEMBER_NOT_FOUND(NOT_FOUND, "사용자가 존재하지 않습니다"),
 
+	//signUp
+	DUPLICATE_EMAIL(BAD_REQUEST, "이미 가입되어있는 이메일입니다."),
+
 	//Login
 	INVALID_TOKEN(UNAUTHORIZED, "잘못된 JWT 토큰입니다"),
 	EXPIRED_TOKEN(UNAUTHORIZED, "만료된 JWT 토큰입니다."),
@@ -26,6 +29,12 @@ public enum ErrorCode {
 	INVALID_LOGOUT_REQUEST(BAD_REQUEST, "로그아웃 요청이 잘못되었습니다."),
 	INVALID_REFRESH_TOKEN(UNAUTHORIZED, "유효하지 않은 Refresh Token 입니다."),
 	TOKEN_REGISTRATION_FAILED(INTERNAL_SERVER_ERROR, "Access Token 을 블랙리스트에 등록하는 중 서버 오류가 발생했습니다."),
+
+	// LinkId
+	ALREADY_LINKED_ACCOUNT(HttpStatus.BAD_REQUEST, "이미 연동된 소셜 계정입니다."),
+	SOCIAL_ACCOUNT_NOT_LINKED(HttpStatus.BAD_REQUEST, "연동된 소셜 계정이 없습니다."),
+	UNSUPPORTED_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 유형입니다."),
+	INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 토큰입니다."),
 
 	//Category
 	CATEGORY_NOT_FOUND(NOT_FOUND, "카테고리가 존재하지 않습니다."),

--- a/backend/src/main/java/com/tripmarket/global/oauth2/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/tripmarket/global/oauth2/service/CustomOAuth2UserService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.tripmarket.domain.member.entity.Member;
 import com.tripmarket.domain.member.entity.Provider;
 import com.tripmarket.domain.member.repository.MemberRepository;
+import com.tripmarket.domain.member.repository.SocialAccountLinkRepository;
 import com.tripmarket.global.oauth2.CustomOAuth2User;
 import com.tripmarket.global.oauth2.userinfo.GithubOAuth2UserInfo;
 import com.tripmarket.global.oauth2.userinfo.GoogleOAuth2UserInfo;
@@ -34,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
 	private final MemberRepository memberRepository;
+	private final SocialAccountLinkRepository socialAccountLinkRepository;
 
 	/**
 	 * OAuth2 인증 후 받아온 사용자 정보를 처리
@@ -53,9 +55,9 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
 		// OAuth2 로그인 시 키가 되는 필드값 (PK)
 		String usernameAttributeName = userRequest.getClientRegistration()
-			.getProviderDetails()
-			.getUserInfoEndpoint()
-			.getUserNameAttributeName();
+				.getProviderDetails()
+				.getUserInfoEndpoint()
+				.getUserNameAttributeName();
 		log.info("Username attribute name: {}", usernameAttributeName);
 
 		// OAuth2UserInfo 객체 생성
@@ -67,52 +69,54 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 		};
 
 		log.info("Extracted user info - id:{}, email: {}, name: {}",
-			userInfo.getId(), userInfo.getEmail(), userInfo.getName());
+				userInfo.getId(), userInfo.getEmail(), userInfo.getName());
 
 		// 유저 정보 저장 또는 업데이트
-		Member member = saveOrUpdate(userInfo, registrationId);
+		Member member = saveOrUpdateWithLinking(userInfo, registrationId);
 		log.info("Saved/Updated member - id: {}, email: {}",
-			member.getId(), member.getEmail());
+				member.getId(), member.getEmail());
 
 		return new CustomOAuth2User(
-			Collections.singleton(new SimpleGrantedAuthority(member.getRole().name())),
-			oAuth2User.getAttributes(),
-			usernameAttributeName,
-			member.getId(),
-			member.getEmail()
-		);
+				Collections.singleton(new SimpleGrantedAuthority(member.getRole().name())),
+				oAuth2User.getAttributes(),
+				usernameAttributeName,
+				member.getId(),
+				member.getEmail());
 	}
 
 	/**
 	 * OAuth2 사용자 정보로 회원가입 또는 정보 업데이트
 	 *
-	 * @param userInfo OAuth2 제공자로부터 받은 사용자 정보
+	 * @param userInfo       OAuth2 제공자로부터 받은 사용자 정보
 	 * @param registrationId OAuth2 서비스 구분자 (kakao, google 등)
 	 * @return 저장 또는 업데이트된 회원 엔티티
 	 */
-	private Member saveOrUpdate(OAuth2UserInfo userInfo, String registrationId) {
+	private Member saveOrUpdateWithLinking(OAuth2UserInfo userInfo, String registrationId) {
 		Provider provider = getProvider(registrationId);
+
+		// 1. 소셜 계정이 이미 있는지 확인 (Provider + ProviderId로)
 		Optional<Member> optionalMember = memberRepository
-			.findByProviderAndProviderId(provider, userInfo.getId());
+				.findByProviderAndProviderId(provider, userInfo.getId());
 
 		if (optionalMember.isPresent()) {
-			// 기존 회원이면 정보 업데이트
+			// 기존 소셜 계정이 있으면 정보 업데이트하고 해당 계정으로 로그인
 			Member member = optionalMember.get();
 			member.updateOAuth2Profile(
-				userInfo.getName(),
-				userInfo.getImageUrl()
-			);
+					userInfo.getName(),
+					userInfo.getImageUrl());
+			log.info("기존 소셜 계정으로 로그인: {}", member.getEmail());
 			return member;
-
 		} else {
-			// 새 회원이면 회원가입
+			// 2. 새 소셜 계정 생성 및 반환 (일반 계정 연동 여부 무시)
 			Member member = Member.createSocialMember(userInfo, provider);
+			log.info("신규 소셜 계정 생성: {}, provider: {}", userInfo.getEmail(), provider);
 			return memberRepository.save(member);
 		}
 	}
 
 	/**
 	 * registrationId를 Provider enum으로 변환
+	 * 
 	 * @param registrationId OAuth2 서비스 구분 ID (kakao, google 등)
 	 * @throws OAuth2AuthenticationException 지원하지 않는 OAuth2 제공자일 경우
 	 */

--- a/backend/src/main/java/com/tripmarket/global/oauth2/service/OAuth2UserInfoService.java
+++ b/backend/src/main/java/com/tripmarket/global/oauth2/service/OAuth2UserInfoService.java
@@ -1,0 +1,115 @@
+package com.tripmarket.global.oauth2.service;
+
+import java.util.Map;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.tripmarket.domain.member.entity.Provider;
+import com.tripmarket.global.exception.CustomException;
+import com.tripmarket.global.exception.ErrorCode;
+import com.tripmarket.global.oauth2.userinfo.GithubOAuth2UserInfo;
+import com.tripmarket.global.oauth2.userinfo.GoogleOAuth2UserInfo;
+import com.tripmarket.global.oauth2.userinfo.KakaoOAuth2UserInfo;
+import com.tripmarket.global.oauth2.userinfo.OAuth2UserInfo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 소셜 토큰으로 사용자 정보를 조회하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2UserInfoService {
+	private final RestTemplate restTemplate = new RestTemplate();
+
+	/**
+	 * 소셜 토큰으로 사용자 정보 조회
+	 */
+	public OAuth2UserInfo loadUserInfoByToken(Provider provider, String token) {
+		return switch (provider) {
+			case KAKAO -> loadKakaoUserByToken(token);
+			case GOOGLE -> loadGoogleUserByToken(token);
+			case GITHUB -> loadGithubUserByToken(token);
+			default -> throw new CustomException(ErrorCode.UNSUPPORTED_SOCIAL_TYPE);
+		};
+	}
+
+	/**
+	 * 카카오 토큰으로 사용자 정보 조회
+	 */
+	private OAuth2UserInfo loadKakaoUserByToken(String token) {
+		String userInfoEndpoint = "https://kapi.kakao.com/v2/user/me";
+
+		try {
+			Map<String, Object> response = restTemplate.exchange(
+				userInfoEndpoint,
+				HttpMethod.GET,
+				new HttpEntity<>(createAuthHeaders(token)),
+				new ParameterizedTypeReference<Map<String, Object>>() {}
+			).getBody();
+
+			return new KakaoOAuth2UserInfo(response);
+		} catch (Exception e) {
+			log.error("카카오 사용자 정보 조회 실패", e);
+			throw new CustomException(ErrorCode.INVALID_SOCIAL_TOKEN);
+		}
+	}
+
+	/**
+	 * 구글 토큰으로 사용자 정보 조회
+	 */
+	private OAuth2UserInfo loadGoogleUserByToken(String token) {
+		String userInfoEndpoint = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+		try {
+			Map<String, Object> response = restTemplate.exchange(
+				userInfoEndpoint,
+				HttpMethod.GET,
+				new HttpEntity<>(createAuthHeaders(token)),
+				new ParameterizedTypeReference<Map<String, Object>>() {}
+			).getBody();
+
+			return new GoogleOAuth2UserInfo(response);
+		} catch (Exception e) {
+			log.error("구글 사용자 정보 조회 실패", e);
+			throw new CustomException(ErrorCode.INVALID_SOCIAL_TOKEN);
+		}
+	}
+
+	/**
+	 * 깃허브 토큰으로 사용자 정보 조회
+	 */
+	private OAuth2UserInfo loadGithubUserByToken(String token) {
+		String userInfoEndpoint = "https://api.github.com/user";
+
+		try {
+			Map<String, Object> response = restTemplate.exchange(
+				userInfoEndpoint,
+				HttpMethod.GET,
+				new HttpEntity<>(createAuthHeaders(token)),
+				new ParameterizedTypeReference<Map<String, Object>>() {}
+			).getBody();
+
+			return new GithubOAuth2UserInfo(response);
+		} catch (Exception e) {
+			log.error("깃허브 사용자 정보 조회 실패", e);
+			throw new CustomException(ErrorCode.INVALID_SOCIAL_TOKEN);
+		}
+	}
+
+	/**
+	 * 인증 헤더 생성
+	 */
+	private HttpHeaders createAuthHeaders(String token) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBearerAuth(token);
+		return headers;
+	}
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 
1. 같은 이메일로 다른 로그인 방식으로 회원가입시 중복으로 인해 가입이 불가능
2. member엔티티의 email 필드 unique 해제 시 다른 사용자의 같은 계정이 가입이 가능하여 로그인 로직의 오류 발생

## 👩‍💻 요구 사항과 구현 내용 
[문제 상황]
1. 이메일 중복 불가 문제
- 일반 계정과 소셜 계정이 같은 이메일을 사용할 수 없음
- DB 제약조건(unique=true)으로 인해 같은 이메일로 다른 로그인 방식 사용 불가
2. 로그인 실패 오류
- 소셜 계정으로 가입 후 같은 이메일로 일반 계정 가입 시도 → 실패
- 일반 계정으로 가입 후 같은 이메일로 소셜 로그인 시도 → 실패
3. 인증 로직 불일치
- 일반 로그인: email로 사용자 조회
- 소셜 로그인: provider+providerId로 사용자 조회
- 두 방식 간 불일치로 인한 혼란

[예상 사용자 시나리오 정의]
1. 시나리오 1: 동일 사용자의 여러 계정
- 사용자 A가 이메일 "user@example.com"으로 일반 계정 가입
- 같은 사용자 A가 동일 이메일로 구글 소셜 로그인 시도
- 이메일이 같아도 Provider가 다르므로 별도 계정으로 생성됨

2. 시나리오 2: 서로 다른 사용자의 동일 이메일
- 사용자 A가 이메일 "user@example.com"으로 일반 계정 가입
- 다른 사용자 B가 동일 이메일로 카카오 소셜 로그인 시도
- 마찬가지로 Provider가 다르므로 별도 계정으로 생성됨
- 실제 이메일 소유자만 이메일 인증을 통과할 수 있으므로 문제 없음

3. 시나리오 3: 일반 계정 중복 방지
- 사용자 A가 이메일 "user@example.com"으로 일반 계정 가입
- 다른 사용자 B가 동일 이메일로 일반 계정 가입 시도
- 이메일+Provider(LOCAL) 조합이 이미 존재하므로 회원가입 거부됨
- 적절한 오류 메시지로 사용자에게 안내

[문제 해결 방안]
1. 데이터베이스 제약조건 변경
- email 필드에서 unique 제약조건 제거
- @table 어노테이션 사용하여 email + provider 조합으로 복합 유니크 제약조건 추가

2. 사용자 조회 로직 통일
- 일반 로그인 시에도 provider를 함께 고려하도록 수정

3. 회원가입 중복 체크 로직 수정

[결과]
1. 이메일 중복 허용 규칙
- 일반 계정끼리는 이메일 중복 불가 (기존과 동일)
- 소셜 계정과 일반 계정 간에는 이메일 중복 허용
- 각 소셜 Provider 간에도, 이메일 중복 허용 (예: 카카오, 구글 동일 이메일)
- 
2. 식별 메커니즘
- 모든 타입의 계정을 email + provider 조합으로 식별
- 일반 계정: email + Provider.LOCAL
- 소셜 계정: email + Provider.GOOGLE/KAKAO 등

3. 실제 동작 방식
- 일반 로그인: 이메일 + LOCAL 제공자로 조회
- 소셜 로그인: 소셜 ID + 해당 제공자로 조회
- 각 인증 채널별 독립적인 사용자 식별 가능


## ✅ 피드백 반영사항  
- 소셜 및 일반 로그인 기능 구현에서 이메일 중복에 의한 문제 해결을 요청

## ✅ PR 포인트 & 궁금한 점 